### PR TITLE
Modify the HTTP Server to Use Any Port

### DIFF
--- a/server/src/handlers.test.ts
+++ b/server/src/handlers.test.ts
@@ -4,55 +4,42 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { handleStaticFile } from "./handlers.js";
+import { httpServerListenToAnyPort } from "./server.js";
 
-describe("Handle static files", { concurrent: true }, () => {
+describe("handleStaticFile", { concurrent: true }, () => {
   let publicDir: string;
   beforeAll(async () => {
     publicDir = await mkdtemp(path.join(os.tmpdir(), "temp"));
     await writeFile(path.join(publicDir, "index.html"), "<!doctype html>");
   });
 
-  let server: http.Server;
+  let url: string;
   beforeAll(async () => {
-    server = new http.Server((req, res) => {
+    const server = new http.Server((req, res) => {
       handleStaticFile(publicDir, req, res);
     });
 
-    await new Promise<void>((resolve) => {
-      server.listen(3000, resolve);
-    });
+    const port = await httpServerListenToAnyPort(server);
+    url = `http://localhost:${port.toString()}`;
   });
 
   it("should serve root path", async () => {
-    const res = await fetch("http://localhost:3000/");
+    const res = await fetch(url);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/html");
   });
 
   it("should serve index.html", async () => {
-    const res = await fetch("http://localhost:3000/index.html");
+    const res = await fetch(`${url}/index.html`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/html");
   });
 
   it("should return 404 for non-existent files", async () => {
-    const res = await fetch("http://localhost:3000/nonexistent");
+    const res = await fetch(`${url}/nonexistent`);
     expect(res.status).toBe(404);
     expect(res.headers.get("content-type")).toBe("text/plain");
   });
-
-  afterAll(
-    () =>
-      new Promise<void>((resolve, reject) => {
-        server.close((err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        });
-      }),
-  );
 
   afterAll(() => rm(publicDir, { recursive: true }));
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@
 
 import * as http from "node:http";
 import { handleStaticFile } from "./handlers.js";
+import { httpServerListenToAnyPort } from "./server.js";
 
 const publicDir = process.env.PUBLIC_DIR;
 if (!publicDir) {
@@ -17,6 +18,5 @@ const server = http.createServer((req, res) => {
   }
 });
 
-server.listen(3000, () => {
-  console.log(`Server running at http://localhost:3000`);
-});
+const port = await httpServerListenToAnyPort(server);
+console.log(`Server running at http://localhost:${port.toString()}`);

--- a/server/src/server.test.ts
+++ b/server/src/server.test.ts
@@ -1,0 +1,14 @@
+import * as http from "node:http";
+import { describe, expect, it } from "vitest";
+import { httpServerListenToAnyPort } from "./server.js";
+
+describe("httpServerListenToAnyPort", { concurrent: true }, () => {
+  it("should return a port number when server listens successfully", async () => {
+    const server = http.createServer();
+    const port = await httpServerListenToAnyPort(server);
+
+    expect(typeof port).toBe("number");
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,14 @@
+import * as http from "node:http";
+import { AddressInfo } from "node:net";
+
+export async function httpServerListenToAnyPort(
+  server: http.Server,
+): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, resolve);
+  });
+
+  const addr = server.address() as AddressInfo;
+  return addr.port;
+}


### PR DESCRIPTION
This pull request resolves #12 by adding a new `httpServerListenToAnyPort` utility function that allows an HTTP server to listen on any available port and returns the port being used by the server.