### PR TITLE
Lock pnpm to Version 10.33.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
   "devDependencies": {
     "lefthook": "^2.0.13",
     "prettier": "^3.7.4"
-  }
+  },
+  "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
This pull request resolves #27 by locking the pnpm version used in this project to version 10.33.4 both in the GitHub Actions workflows and `package.json`.